### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -2,26 +2,26 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-Motivator			KEYWORD1
-Behavior			KEYWORD1
+Motivator	KEYWORD1
+Behavior	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-enableBehavior		KEYWORD2
-disableBehavior		KEYWORD2
-addBehavior			KEYWORD2
+enableBehavior	KEYWORD2
+disableBehavior	KEYWORD2
+addBehavior	KEYWORD2
 executeBehaviors	KEYWORD2
-addConflict			KEYWORD2
-enable				KEYWORD2
-disable				KEYWORD2
-getEnabled			KEYWORD2
-init				KEYWORD2
-execute				KEYWORD2
+addConflict	KEYWORD2
+enable	KEYWORD2
+disable	KEYWORD2
+getEnabled	KEYWORD2
+init	KEYWORD2
+execute	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
 
-M_BEHAVIORS			LITERAL1
+M_BEHAVIORS	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords